### PR TITLE
Add missing header <cfloat> for FLT_MAX

### DIFF
--- a/gaussian_splatting/submodules/simple-knn/simple_knn.cu
+++ b/gaussian_splatting/submodules/simple-knn/simple_knn.cu
@@ -14,6 +14,7 @@
 #include "cuda_runtime.h"
 #include "device_launch_parameters.h"
 #include "simple_knn.h"
+#include <cfloat>
 #include <cub/cub.cuh>
 #include <cub/device/device_radix_sort.cuh>
 #include <vector>


### PR DESCRIPTION
Hi, thanks for this new GS framework.

It seems `<cfloat>` is needed for `FLT_MAX` in `simple_knn.cu`.

See
[https://gitlab.inria.fr/bkerbl/simple-knn/-/commit/86710c2d4b46680c02301765dd79e465819c8f19](url)

Thanks for your attention.